### PR TITLE
Don’t log SEVERE error on initial startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.modules</groupId>
   <artifactId>instance-identity</artifactId>
-  <version>1.6-SNAPSHOT</version>
+  <version>1.5.1-SNAPSHOT</version>
   <packaging>jenkins-module</packaging>
   <name>Instance Identity</name>
   <description>Maintains an RSA key pair that can serve as a foundation of authentication when communicating with Jenkins</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.53</version>
+      <version>1.54</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
+++ b/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.security.CryptoConfidentialKey;
 import org.apache.commons.io.FileUtils;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.PEMKeyPair;
@@ -108,7 +109,7 @@ public class InstanceIdentity {
 
     private static void write(KeyPair keys, File keyFile) throws IOException {
         StringWriter sw = new StringWriter();
-        PEMWriter w = new PEMWriter(sw);
+        JcaPEMWriter w = new JcaPEMWriter(sw);
         try {
             w.writeObject(keys);
         } finally {

--- a/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
+++ b/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
@@ -4,6 +4,7 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.model.PageDecorator;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
@@ -85,12 +86,15 @@ public class InstanceIdentity {
                 Object o = r.readObject();
                 JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider(provider);
                 keyPair = converter.getKeyPair((PEMKeyPair) o);
+            } catch (FileNotFoundException e) {
+                LOGGER.fine("identity.key.enc doesn't exist. New Identity.key.enc will be generated");
+                return null;
             } catch (GeneralSecurityException x) {
-                LOGGER.log(Level.SEVERE, String.format("identity.key.enc is corrupted. Identity.key.enc will be deleted and a new one will be generated"), x);
+                LOGGER.log(Level.SEVERE, "identity.key.enc is corrupted. Identity.key.enc will be deleted and a new one will be generated", x);
                 return null;
             } catch (IOException e) {
-                    LOGGER.log(Level.SEVERE, String.format("identity.key.enc doesn't exist. New Identity.key.enc will be generated"), e);
-                    return null;
+                LOGGER.log(Level.SEVERE, "failed to access identity.key.enc. Identity.key.enc will be deleted and a new one will be generated", e);
+                return null;
             }
         } else if (oldKeyFile != null) { //Get the Reader for oldKeyFile
             in = new FileReader(oldKeyFile);


### PR DESCRIPTION
When Jenkins starts with 1.5 a SEVERE error is logged due to missing key file, which is actually expected in this context. So distinguish `file not found` vs other IO errors