### PR TITLE
Update documentation towards the 2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+Changelog
+=========
+
+## 2.2
+
+Release date: June 27, 2018
+
+* [PR #11](https://github.com/jenkinsci/instance-identity-module/pull/11) -
+Replace usages of the deprecated `java.xml.bind` classes from (JAXB)
+by modern Java 8+ API.
+Part of [JENKINS-51965](https://issues.jenkins-ci.org/browse/JENKINS-51965) patches.
+* [PR #9](https://github.com/jenkinsci/instance-identity-module/pull/9) -
+Remove the obsolete `InstanceIdentityProvider` class available in Jenkins core
+starting from 2.16
+
+## Previous releases
+
+See the commit history and [Jenkins changelog](https://jenkins.io/changelog/).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+Instance Identity module for Jenkins
+====================================
+
+This module maintains an RSA key pair that can serve
+as a foundation of authentication when communicating with Jenkins.
+
+## Description
+
+Each Jenkins instance maintains an RSA private/public key pair
+that can be used to uniquely identify Jenkins.
+This information is called "instance identity".
+
+From outside, the public key can be obtained by sending the GET request
+to the top page of Jenkins,
+and look for the _X-Instance-Identity_ header in the response.
+This header is always available, even if the response is 401 access denied
+(which can happen if Jenkins is protected via security.)
+The value represents a base64-encoded ASN.1 DER serialization of X.509 SubjectPublicKeyInfo record.
+
+Plugins that run inside Jenkins can access this key pair programmatically through
+the org.jenkinsci.main.modules.instance_identity.InstanceIdentity class
+(add a provided scope dependency to this module into your plugin).
+
+## Possible use
+
+* Sometimes, a Jenkins server is accessible through multiple URLs.
+  This ID can be used to identify duplicates in those.
+* Plugins can use the private key to produce a digital signature of some data
+  that can be verified later by other parties about its origin.
+
+## License
+
+[MIT License](https://opensource.org/licenses/mit-license.php)
+
+## Changelog
+
+See [Changelog](./CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This header is always available, even if the response is 401 access denied
 The value represents a base64-encoded ASN.1 DER serialization of X.509 SubjectPublicKeyInfo record.
 
 Plugins that run inside Jenkins can access this key pair programmatically through
-the org.jenkinsci.main.modules.instance_identity.InstanceIdentity class
+the `org.jenkinsci.main.modules.instance_identity.InstanceIdentity` class
 (add a provided scope dependency to this module into your plugin).
 
 ## Possible use

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://opensource.org/licenses/mit-license.php</url>
     </license>
   </licenses>
 


### PR DESCRIPTION
Adds README and CHANGELOG to the repository. I need to release #11 and #9, so I would like to have these common files in place.

Docs are mostly taken from https://wiki.jenkins.io/display/JENKINS/Instance+Identity which can be replaced by redirect after the merge

@jenkinsci/java10-support + @kohsuke @stephenc who contributed changes
