### PR TITLE
Make this easier to get the encoded public key

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
+++ b/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
@@ -129,6 +129,10 @@ public class InstanceIdentity {
         return (RSAPrivateKey) keys.getPrivate();
     }
 
+    /**
+     * @since TODO
+     * @return the encoded RSA public key.
+     */
     public String getEncodedPublicKey() {
         RSAPublicKey key = getPublic();
         return new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));

--- a/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
+++ b/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
@@ -131,8 +131,8 @@ public class InstanceIdentity {
     }
 
     /**
-     * @since TODO
      * @return the encoded RSA public key.
+     * @since TODO
      */
     public String getEncodedPublicKey() {
         RSAPublicKey key = getPublic();

--- a/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
+++ b/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
@@ -11,6 +11,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -135,7 +136,7 @@ public class InstanceIdentity {
      */
     public String getEncodedPublicKey() {
         RSAPublicKey key = getPublic();
-        return new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
+        return new String(Base64.encodeBase64(key.getEncoded()), StandardCharsets.UTF_8);
     }
 
     public static InstanceIdentity get() {

--- a/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
+++ b/src/main/java/org/jenkinsci/main/modules/instance_identity/InstanceIdentity.java
@@ -10,6 +10,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -23,6 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.security.CryptoConfidentialKey;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.main.modules.instance_identity.pem.PEMHelper;
 
@@ -125,6 +127,11 @@ public class InstanceIdentity {
 
     public RSAPrivateKey getPrivate() {
         return (RSAPrivateKey) keys.getPrivate();
+    }
+
+    public String getEncodedPublicKey() {
+        RSAPublicKey key = getPublic();
+        return new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
     }
 
     public static InstanceIdentity get() {

--- a/src/main/java/org/jenkinsci/main/modules/instance_identity/PageDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/instance_identity/PageDecoratorImpl.java
@@ -23,7 +23,6 @@ public class PageDecoratorImpl extends PageDecorator {
     }
 
     public String getEncodedPublicKey() {
-        RSAPublicKey key = identity.getPublic();
-        return new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
+        return identity.getEncodedPublicKey();
     }
 }


### PR DESCRIPTION
Avoid having people either use the PageDecorator, or copy paste the encoding lines to go from RSAPublicKey to String.

Loosely related to https://issues.jenkins-ci.org/browse/JENKINS-54266 where I would have used this :-)