### PR TITLE
Update to 3.36 parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.12</version>
+    <version>3.36</version>
   </parent>
 
   <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
This fixes the build failure seen using Maven 3.6.0, posted by @oleg-nenashev on https://github.com/jenkinsci/instance-identity-module/pull/13#issuecomment-459724752